### PR TITLE
Implemented search

### DIFF
--- a/backend/constants.ts
+++ b/backend/constants.ts
@@ -1,3 +1,5 @@
+import { Prisma } from "@prisma/client";
+
 export const DEFAULT_PAGE_LIMIT = 10;
 
 export const PRISMA_SELECT_USER_SUMMARY = {
@@ -44,3 +46,20 @@ export const PRISMA_SELECT_USER = {
     asks: { select: PRISMA_SELECT_ASK },
     offers: { select: PRISMA_SELECT_OFFER }
 };
+
+export const PRISMA_WHERE_TITLE_OR_DESCRIPTION_CONTAINS_SUBSTRING = (searchString?: string) => ({
+    OR: [
+        {
+            title: {
+                contains: searchString,
+                mode: 'insensitive' as Prisma.QueryMode
+            }
+        },
+        {
+            description: {
+                contains: searchString,
+                mode: 'insensitive' as Prisma.QueryMode
+            }
+        }
+    ]
+});

--- a/backend/controller/ask.ts
+++ b/backend/controller/ask.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { AskService } from '../service/ask';
-import { getUserIdOrError } from './utils';
-import { CreateAskBody, CreateAskResponse, DeleteAskResponse, GetManyAskResponse, GetOneAskResponse, UpdateAskBody, UpdateAskResponse } from '../../shared/apiTypes';
+import { getUserIdOrError, parseGetManyOptions } from './utils';
+import { CreateAskBody, CreateAskResponse, DeleteAskResponse, GetManyAskResponse, GetManyOptions, GetOneAskResponse, UpdateAskBody, UpdateAskResponse } from '../../shared/apiTypes';
 import { CreateAskParams, UpdateAskParams } from '../types';
 
 export const askRouter = Router();
@@ -10,9 +10,8 @@ export const askRouter = Router();
 askRouter.get('/', async (req, res) => {
     const {error} = getUserIdOrError(req, res);
     if (error) return;
-    const offset = parseInt(req.query.offset as string) || undefined;
-    const limit = parseInt(req.query.limit as string) || undefined;
-    const result: GetManyAskResponse = await AskService().getMany(offset, limit);
+    const options = parseGetManyOptions(req);
+    const result: GetManyAskResponse = await AskService().getMany(options);
     res.json(result);
 });
 
@@ -37,9 +36,8 @@ askRouter.get('/:id', async (req, res) => {
 askRouter.get('/user', async (req, res) => {
     const {userId, error} = getUserIdOrError(req, res);
     if (error) return;
-    const offset = parseInt(req.query.offset as string) || undefined;
-    const limit = parseInt(req.query.limit as string) || undefined;
-    const result: GetManyAskResponse | null = await AskService().getManyByUser(userId, offset, limit);
+    const options = parseGetManyOptions(req);
+    const result: GetManyAskResponse | null = await AskService().getManyByUser(userId, options);
     if (!result) {
         res.status(404).end();
         return;
@@ -50,9 +48,8 @@ askRouter.get('/user', async (req, res) => {
 // GET_MANY_BY_USER
 askRouter.get('/user/:id', async (req, res) => {
     const id = req.params.id;
-    const offset = parseInt(req.query.offset as string) || undefined;
-    const limit = parseInt(req.query.limit as string) || undefined;
-    const result: GetManyAskResponse | null = await AskService().getManyByUser(id, offset, limit);
+    const options = parseGetManyOptions(req);
+    const result: GetManyAskResponse | null = await AskService().getManyByUser(id, options);
     if (!result) {
         res.status(404).end();
         return;

--- a/backend/controller/offer.ts
+++ b/backend/controller/offer.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { OfferService } from '../service/offer';
-import { getUserIdOrError } from './utils';
+import { getUserIdOrError, parseGetManyOptions } from './utils';
 import { CreateOfferBody, CreateOfferResponse, DeleteOfferResponse, GetManyOfferResponse, GetOneOfferResponse, UpdateOfferBody, UpdateOfferResponse } from '../../shared/apiTypes';
 import { CreateOfferParams, UpdateOfferParams } from '../types';
 
@@ -10,9 +10,8 @@ export const offerRouter = Router();
 offerRouter.get('/', async (req, res) => {
     const {error} = getUserIdOrError(req, res);
     if (error) return;
-    const offset = parseInt(req.query.offset as string) || undefined;
-    const limit = parseInt(req.query.limit as string) || undefined;
-    const result: GetManyOfferResponse = await OfferService().getMany(offset, limit);
+    const options = parseGetManyOptions(req);
+    const result: GetManyOfferResponse = await OfferService().getMany(options);
     res.json(result);
 });
 
@@ -37,9 +36,8 @@ offerRouter.get('/:id', async (req, res) => {
 offerRouter.get('/user', async (req, res) => {
     const {userId, error} = getUserIdOrError(req, res);
     if (error) return;
-    const offset = parseInt(req.query.offset as string) || undefined;
-    const limit = parseInt(req.query.limit as string) || undefined;
-    const result: GetManyOfferResponse | null = await OfferService().getManyByUser(userId, offset, limit);
+    const options = parseGetManyOptions(req);
+    const result: GetManyOfferResponse | null = await OfferService().getManyByUser(userId, options);
     if (!result) {
         res.status(404).end();
         return;
@@ -50,9 +48,8 @@ offerRouter.get('/user', async (req, res) => {
 // GET_MANY_BY_USER
 offerRouter.get('/user/:id', async (req, res) => {
     const id = req.params.id;
-    const offset = parseInt(req.query.offset as string) || undefined;
-    const limit = parseInt(req.query.limit as string) || undefined;
-    const result: GetManyOfferResponse | null = await OfferService().getManyByUser(id, offset, limit);
+    const options = parseGetManyOptions(req);
+    const result: GetManyOfferResponse | null = await OfferService().getManyByUser(id, options);
     if (!result) {
         res.status(404).end();
         return;

--- a/backend/controller/utils.ts
+++ b/backend/controller/utils.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { GetManyOptions } from "../../shared/apiTypes";
 
 export const getUserIdOrError = (req: Request, res: Response) => {
     if (!req.user || !req.user.id) {
@@ -8,4 +9,13 @@ export const getUserIdOrError = (req: Request, res: Response) => {
         return { userId: '', error};
     }
     return {userId: req.user.id, error: null}
+}
+
+export const parseGetManyOptions = (req: Request) => {
+    const options: GetManyOptions = {
+        limit: parseInt(req.query.limit as string) || undefined,
+        offset: parseInt(req.query.offset as string) || undefined,
+        searchString: req.query.searchString?.toString?.() || ''
+    };
+    return options;
 }

--- a/backend/service/offer.ts
+++ b/backend/service/offer.ts
@@ -2,12 +2,13 @@ import { Prisma } from '@prisma/client';
 import type { Offer } from '../../shared/types'
 import { prismaClient } from '../prismaClient';
 import { CreateOfferParams, SetOffersForUserParams, UpdateOfferParams } from '../types';
-import { DEFAULT_PAGE_LIMIT, PRISMA_SELECT_OFFER } from "../constants";
+import { DEFAULT_PAGE_LIMIT, PRISMA_SELECT_OFFER, PRISMA_WHERE_TITLE_OR_DESCRIPTION_CONTAINS_SUBSTRING } from "../constants";
+import { GetManyOptions } from '../../shared/apiTypes';
 
 export interface IOfferService {
     getOne(id: string): Promise<Offer | null>;
-    getMany(offset?: number, limit?: number): Promise<Offer[]>;
-    getManyByUser(id: string, offset?: number, limit?: number): Promise<Offer[]>;
+    getMany(options: GetManyOptions): Promise<Offer[]>;
+    getManyByUser(id: string, options: GetManyOptions): Promise<Offer[]>;
     create(data: CreateOfferParams): Promise<Offer>;
     setForUser(userId: string, offers: SetOffersForUserParams): Promise<Offer[]>;
     delete(id: string): Promise<Offer | null>;
@@ -22,8 +23,10 @@ export const OfferService: () => IOfferService = () => ({
         });
         return result;
     },
-    getMany: async (offset = 0, limit = DEFAULT_PAGE_LIMIT) => {
+    getMany: async (options) => {
+        const { offset = 0, limit = DEFAULT_PAGE_LIMIT, searchString = '' } = options;
         const result = await prismaClient.offer.findMany({
+            where: PRISMA_WHERE_TITLE_OR_DESCRIPTION_CONTAINS_SUBSTRING(searchString),
             select: PRISMA_SELECT_OFFER,
             orderBy: { createdAt: 'desc' },
             skip: offset,
@@ -31,9 +34,10 @@ export const OfferService: () => IOfferService = () => ({
         });
         return result;
     },
-    getManyByUser: async (userId, offset = 0, limit = DEFAULT_PAGE_LIMIT) => {
+    getManyByUser: async (userId, options) => {
+        const { offset = 0, limit = DEFAULT_PAGE_LIMIT, searchString = '' } = options;
         const result = await prismaClient.offer.findMany({
-            where: { userId },
+            where: { userId, ...PRISMA_WHERE_TITLE_OR_DESCRIPTION_CONTAINS_SUBSTRING(searchString) },
             select: PRISMA_SELECT_OFFER,
             orderBy: { createdAt: 'desc' },
             skip: offset,

--- a/frontend/src/services/askService.ts
+++ b/frontend/src/services/askService.ts
@@ -7,36 +7,36 @@ import {
   CreateAskResponse,
   DeleteAskResponse,
   GetManyAskResponse,
+  GetManyOptions,
   GetOneAskResponse,
   UpdateAskBody,
   UpdateAskResponse,
 } from "../../../shared/apiTypes";
 
 export interface IAskService {
-  getAsksByCurrentUser(): Promise<Ask[] | null>;
-  getAsksByUser(id: string, offset?: number, limit?: number): Promise<Ask[] | null>;
+  getAsksByCurrentUser(options?: GetManyOptions): Promise<Ask[] | null>;
+  getAsksByUser(id: string, options?: GetManyOptions): Promise<Ask[] | null>;
   getAskById(id: string): Promise<Ask | null>;
   createAskForCurrentUser(bodyObj: CreateAskBody): Promise<Ask | null>;
   updateAskForCurrentUser(id: string, bodyObj: UpdateAskBody): Promise<Ask | null>;
   deleteAskForCurrentUser(id: string): Promise<Ask | null>;
-  getAsks(offset?: number, limit?: number): Promise<Ask[] | null>;
+  getAsks(options?: GetManyOptions): Promise<Ask[] | null>;
 }
 
 const AskService = (getToken: () => Promise<string>): IAskService => ({
-  getAsksByCurrentUser: async () => {
+  getAsksByCurrentUser: async (options) => {
     const url = ENDPOINTS_ASK.GET_MANY_BY_CURRENT_USER;
     const token = await getToken();
-    const asks = await getAuthed<GetManyAskResponse>(url, token);
+    const asks = await getAuthed<GetManyAskResponse>(url, token, options);
     return asks;
   },
-  getAsksByUser: async (id, offset, limit) => {
+  getAsksByUser: async (id, options) => {
     const url = ENDPOINTS_ASK.GET_MANY_BY_USER(id);
     const token = await getToken();
-    const query = {offset, limit};
-    const asks = await getAuthed<GetManyAskResponse>(url, token, query);
+    const asks = await getAuthed<GetManyAskResponse>(url, token, options);
     return asks;
   },
-  getAskById: async (id: string) => {
+  getAskById: async (id) => {
     const url = ENDPOINTS_ASK.GET_ONE(id);
     const token = await getToken();
     const ask = await getAuthed<GetOneAskResponse>(url, token);
@@ -54,17 +54,16 @@ const AskService = (getToken: () => Promise<string>): IAskService => ({
     const ask = await putAuthed<UpdateAskResponse>(url, token, bodyObj);
     return ask;
   },
-  deleteAskForCurrentUser: async (id: string) => {
+  deleteAskForCurrentUser: async (id) => {
     const url = ENDPOINTS_ASK.DELETE(id);
     const token = await getToken();
     const ask = await deleteAuthed<DeleteAskResponse>(url, token);
     return ask;
   },
-  getAsks: async (offset, limit) => {
+  getAsks: async (options) => {
     const url = ENDPOINTS_ASK.GET_MANY;
     const token = await getToken();
-    const query = {offset, limit};
-    const asks = await getAuthed<GetManyAskResponse>(url, token, query);
+    const asks = await getAuthed<GetManyAskResponse>(url, token, options);
     return asks;
   },
 });

--- a/frontend/src/services/offerService.ts
+++ b/frontend/src/services/offerService.ts
@@ -7,36 +7,36 @@ import {
   CreateOfferResponse,
   DeleteOfferResponse,
   GetManyOfferResponse,
+  GetManyOptions,
   GetOneOfferResponse,
   UpdateOfferBody,
   UpdateOfferResponse,
 } from "../../../shared/apiTypes";
 
 export interface IOfferService {
-  getOffersByCurrentUser(): Promise<Offer[] | null>;
-  getOffersByUser(id: string, offset?: number, limit?: number): Promise<Offer[] | null>;
+  getOffersByCurrentUser(options?: GetManyOptions): Promise<Offer[] | null>;
+  getOffersByUser(id: string, options?: GetManyOptions): Promise<Offer[] | null>;
   getOfferById(id: string): Promise<Offer | null>;
   createOfferForCurrentUser(bodyObj: CreateOfferBody): Promise<Offer | null>;
   updateOfferForCurrentUser(id: string, bodyObj: UpdateOfferBody): Promise<Offer | null>;
   deleteOfferForCurrentUser(id: string): Promise<Offer | null>;
-  getOffers(offset?: number, limit?: number): Promise<Offer[] | null>;
+  getOffers(options?: GetManyOptions): Promise<Offer[] | null>;
 }
 
 const OfferService = (getToken: () => Promise<string>): IOfferService => ({
-  getOffersByCurrentUser: async () => {
+  getOffersByCurrentUser: async (options) => {
     const url = ENDPOINTS_OFFER.GET_MANY_BY_CURRENT_USER;
     const token = await getToken();
-    const offers = await getAuthed<GetManyOfferResponse>(url, token);
+    const offers = await getAuthed<GetManyOfferResponse>(url, token, options);
     return offers;
   },
-  getOffersByUser: async (id, offset, limit) => {
+  getOffersByUser: async (id, options) => {
     const url = ENDPOINTS_OFFER.GET_MANY_BY_USER(id);
     const token = await getToken();
-    const query = {offset, limit};
-    const offers = await getAuthed<GetManyOfferResponse>(url, token, query);
+    const offers = await getAuthed<GetManyOfferResponse>(url, token, options);
     return offers;
   },
-  getOfferById: async (id: string) => {
+  getOfferById: async (id) => {
     const url = ENDPOINTS_OFFER.GET_ONE(id);
     const token = await getToken();
     const offer = await getAuthed<GetOneOfferResponse>(url, token);
@@ -54,17 +54,16 @@ const OfferService = (getToken: () => Promise<string>): IOfferService => ({
     const offer = await putAuthed<UpdateOfferResponse>(url, token, bodyObj);
     return offer;
   },
-  deleteOfferForCurrentUser: async (id: string) => {
+  deleteOfferForCurrentUser: async (id) => {
     const url = ENDPOINTS_OFFER.DELETE(id);
     const token = await getToken();
     const offer = await deleteAuthed<DeleteOfferResponse>(url, token);
     return offer;
   },
-  getOffers: async (offset, limit) => {
+  getOffers: async (options) => {
     const url = ENDPOINTS_OFFER.GET_MANY;
     const token = await getToken();
-    const query = {offset, limit};
-    const offers = await getAuthed<GetManyOfferResponse>(url, token, query);
+    const offers = await getAuthed<GetManyOfferResponse>(url, token, options);
     return offers;
   },
 });

--- a/shared/apiTypes.ts
+++ b/shared/apiTypes.ts
@@ -1,5 +1,7 @@
 import { Ask, Offer, Social, User } from "./types";
 
+export type GetManyOptions = {offset?: number, limit?: number, searchString?: string};
+
 export type GetOneAskResponse = Ask;
 export type GetManyAskResponse = Ask[];
 export type CreateAskBody = {title: string, description?: string};


### PR DESCRIPTION
Usage: For any of the frontend services, you can supply an optional `GetManyOptions` arg, as follows:
```ts
type GetManyOptions = {
  offset?: number;
  limit?: number;
  searchString?: string};
}
```
For example, to get 5 asks, on page 2, which all contain the string "help" (case insensitive):
```ts
const currentPage = 2;
const limit = 5;
const offset = (currentPage - 1) * limit;
const searchString = 'help';
const result = await AskService().getAsks({limit, offset, searchString});
```
If unspecified, the default values are:
```
offset: 0
limit: 10
searchString: ''
```